### PR TITLE
[dualscreeninfo] Stub out eventEmitter to prevent crash on ios

### DIFF
--- a/dualscreeninfo/ios/DualScreenInfo.h
+++ b/dualscreeninfo/ios/DualScreenInfo.h
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface DualScreenInfo : NSObject <RCTBridgeModule>
+@interface DualScreenInfo : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/dualscreeninfo/ios/DualScreenInfo.m
+++ b/dualscreeninfo/ios/DualScreenInfo.m
@@ -13,4 +13,9 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
     callback(@[[NSString stringWithFormat: @"numberArgument: %@ stringArgument: %@", numberArgument, stringArgument]]);
 }
 
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"didUpdateSpanning"];
+}
+
 @end


### PR DESCRIPTION
Prevents crash on import, so that I can add this library to an existing app that supports ios.