### PR TITLE
Android: crash fix on non-dual screen device

### DIFF
--- a/dualscreeninfo/android/build.gradle
+++ b/dualscreeninfo/android/build.gradle
@@ -40,4 +40,5 @@ dependencies {
     compileOnly files('libs/com.microsoft.device.display.displaymask.jar')
     compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${_kotlinVersion}"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:${_kotlinVersion}"
 }

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DisplayMaskProxy.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DisplayMaskProxy.kt
@@ -1,0 +1,36 @@
+package com.microsoft.reactnativedualscreen.dualscreen
+
+import android.app.Activity
+import android.graphics.Rect
+import kotlin.reflect.KCallable
+import kotlin.reflect.full.staticFunctions
+
+class DisplayMaskProxy(currentActivity: Activity?) {
+
+    private val mDisplayMask: Any?
+    private val getBoundingRectsForRotationDelegate: KCallable<MutableList<Rect>?>?
+
+    init {
+        var displayMask: Any? = null;
+        var getBoundingRectsForRotation: KCallable<*>? = null;
+        try {
+            if (currentActivity != null) {
+                val displayMaskClass = Class.forName("com.microsoft.device.display.DisplayMask", true, this.javaClass.classLoader)
+                val fromResourcesRect = displayMaskClass.kotlin.staticFunctions.find { m -> m.name == "fromResourcesRect" }
+
+                displayMask = fromResourcesRect?.call(currentActivity)
+                getBoundingRectsForRotation = if (displayMask != null) displayMask::class.members.find { m -> m.name == "getBoundingRectsForRotation" }
+                    else null
+            }
+        } catch (e: ClassNotFoundException) {
+        }
+        getBoundingRectsForRotationDelegate = getBoundingRectsForRotation as KCallable<MutableList<Rect>?>?
+        mDisplayMask = displayMask
+    }
+
+    fun getBoundingRectsForRotation(rotation: Int): MutableList<Rect> {
+        return getBoundingRectsForRotationDelegate?.call(mDisplayMask, rotation) ?: mutableListOf()
+    }
+
+
+}

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -11,7 +11,6 @@ import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
-import com.microsoft.device.display.DisplayMask
 
 
 const val HINGE_WIDTH_KEY = "hingeWidth"
@@ -19,9 +18,9 @@ const val IS_DUALSCREEN_DEVICE_KEY = "isDualScreenDevice"
 const val FEATURE_NAME = "com.microsoft.device.display.displaymask"
 
 class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), LifecycleEventListener  {
-	private val mDisplayMask: DisplayMask?
+	private val mDisplayMask: DisplayMaskProxy
 		get() {
-			return if(currentActivity != null && reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)) DisplayMask.fromResourcesRect(currentActivity) else null
+			return DisplayMaskProxy(currentActivity)
 		}
 	private val rotation: Int
 		get() {
@@ -30,16 +29,17 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 		}
 	private val hinge: Rect
 		get() {
-			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-			return if (boundings == null || boundings.size == 0) {
+			val boundings = mDisplayMask.getBoundingRectsForRotation(rotation)
+
+			return if (boundings.size == 0) {
 				Rect(0, 0, 0, 0)
 			} else boundings[0]
 		}
 	private val windowRects: List<Rect>
 		get() {
-			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
+			val boundings = mDisplayMask.getBoundingRectsForRotation(rotation)
 			val windowBounds = windowRect;
-			return if (boundings == null  || boundings.size == 0) {
+			return if (boundings.size == 0) {
 				listOf(windowBounds)
 			} else {
 				val hingeRect = boundings[0]

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -21,7 +21,7 @@ const val FEATURE_NAME = "com.microsoft.device.display.displaymask"
 class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), LifecycleEventListener  {
 	private val mDisplayMask: DisplayMask?
 		get() {
-			return if(currentActivity != null) DisplayMask.fromResourcesRect(currentActivity) else null
+			return if(currentActivity != null && reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)) DisplayMask.fromResourcesRect(currentActivity) else null
 		}
 	private val rotation: Int
 		get() {


### PR DESCRIPTION
Problem: currently you will get a ClassNotFoundException on import if running on a non-Duo device.

- check if displaymask is available
- if not, don't instantiate the modules which depend on it.
- handle missing native module on ts side

@kikisaints @kmelmon (I don't have permission to request review the normal way)