### PR TITLE
update to account for statusbar when in vertical rotation and twopane

### DIFF
--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -34,6 +34,15 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 				Rect(0, 0, 0, 0)
 			} else boundings[0]
 		}
+	private val mStatusBarHeight: Int
+		get() {
+			var statusBarHeight: Int = 0;
+			val resourceId: Int = reactApplicationContext.resources.getIdentifier("status_bar_height", "dimen", "android")
+			if (resourceId > 0) {
+				statusBarHeight = reactApplicationContext.resources.getDimensionPixelSize(resourceId)
+			}
+			return statusBarHeight;
+		}
 	private val windowRects: List<Rect>
 		get() {
 			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
@@ -47,6 +56,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 					val rightRect = Rect(hingeRect.right, 0, windowBounds.right, windowBounds.bottom)
 					listOf(leftRect, rightRect)
 				} else {
+					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight;
 					val topRect = Rect(0, 0, windowBounds.right, hingeRect.top)
 					val bottomRect = Rect(0, hingeRect.bottom, windowBounds.right, windowBounds.bottom)
 					listOf(topRect, bottomRect)


### PR DESCRIPTION
subtract status bar height for bottom pane when in rendering twopanes and in portrait mode.

this solves the off center issue of our y coordinate when rendering twopanes and in portrait mode. the root cause being that currently  our renderer still thinks theirs a status bar on our bottom screen when in reality when in portrait mode we only have one status bar in our top pane and their is no bottom statusbar