### PR TITLE
Bug fix: DisplayMask may not be initialized before onResume

### DIFF
--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -90,16 +90,15 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 	private var mWindowRects: List<Rect> = emptyList()
 	private var mRotation: Int = Surface.ROTATION_0
 
+	private val onLayoutChange = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+		emitUpdateStateEvent()
+	}
+
 	override fun getName() = "DualScreenInfo"
 
 	override fun initialize() {
 		super.initialize()
 		reactApplicationContext.addLifecycleEventListener(this)
-
-		val rootView: View? = currentActivity?.window?.decorView?.rootView
-		rootView?.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-			emitUpdateStateEvent()
-		}
 	}
 
 	override fun getConstants(): Map<String, Any>? {
@@ -111,10 +110,15 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
     }
 
 	override fun onHostResume() {
-		emitUpdateStateEvent()
+		val rootView: View? = currentActivity?.window?.decorView?.rootView
+		rootView?.addOnLayoutChangeListener(onLayoutChange)
+
 	}
 
-	override fun onHostPause() {}
+	override fun onHostPause() {
+		val rootView: View? = currentActivity?.window?.decorView?.rootView
+		rootView?.removeOnLayoutChangeListener(onLayoutChange)
+	}
 
 	override fun onHostDestroy() {}
 


### PR DESCRIPTION
Bug: After closing (i.e. back out all the way, NOT force-quit) the app, then reopening it, DisplayMask won't be initialized properly. I have a consistent repro in my client app - window rects have zero dimension, spanning isn't detected, etc.

Fix: Only query DisplayMask on/after onResume.