### PR TITLE
subtract status bar when in twopane mode with no rotation

### DIFF
--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -66,6 +66,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 			} else {
 				val hingeRect = boundings[0]
 				if (hingeRect.top == 0) {
+					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
 					val leftRect = Rect(0, 0, hingeRect.left, windowBounds.bottom)
 					val rightRect = Rect(hingeRect.right, 0, windowBounds.right, windowBounds.bottom)
 					listOf(leftRect, rightRect)

--- a/dualscreeninfo/package.json
+++ b/dualscreeninfo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-dualscreeninfo",
   "title": "React Native DualScreenInfo",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "React Native package for dual screen devices support (Surface Duo)",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",


### PR DESCRIPTION
notice that when in twopane mode and in normal portrait rotation it is not subtracting out the statusbar height