### PR TITLE
Update package.json to include the windows folder under exported files

### DIFF
--- a/dualscreeninfo/package.json
+++ b/dualscreeninfo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-dualscreeninfo",
   "title": "React Native DualScreenInfo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React Native package for dual screen devices support (Surface Duo)",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",
@@ -66,6 +66,7 @@
     "tslint.json",
     "*.md",
     "*.podspec",
-    "LICENSE"
+    "LICENSE",
+    "windows"
   ]
 }


### PR DESCRIPTION
The list of included files did not include the windows folder, which required react-native-windows users to patch in the windows file to use the package. I believe this is what's needed to get this working out of the box.