### PR TITLE
Take system bars into account for all orientations

### DIFF
--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -49,14 +49,14 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 			return stableInsetTop ?: 0
 		}
 
-	private val mNavigationBarHeight: Int
+	private val mBottomNavBarHeight: Int
 		@RequiresApi(Build.VERSION_CODES.M)
 		get() {
 			val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetBottom
 			return stableInsetBottom ?: 0
 		}
 
-	private val mNavigationBarWidth: Int
+	private val mRightNavBarHeight: Int
 		@RequiresApi(Build.VERSION_CODES.M)
 		get() {
 			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
@@ -66,7 +66,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 	private val windowRects: List<Rect>
 		get() {
 			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-			var barHeights = mStatusBarHeight + mNavigationBarHeight;
+			var barHeights = mStatusBarHeight + mBottomNavBarHeight;
 			val windowBounds = windowRect;
 			return if (boundings == null || boundings.size == 0) {
 				if (rotationToOrientationString(rotation) == "portrait" || rotationToOrientationString(rotation) == "portraitFlipped") {
@@ -75,7 +75,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 				} else {
 					//single screen landscape
 					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
-					windowBounds.right = windowBounds.right - mNavigationBarWidth
+					windowBounds.right = windowBounds.right - mRightNavBarHeight
 				}
 				listOf(windowBounds)
 			} else {
@@ -88,7 +88,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 					listOf(leftRect, rightRect)
 				} else {
 					// dual screen landscape mode
-					windowBounds.right = windowBounds.right - mNavigationBarWidth;
+					windowBounds.right = windowBounds.right - mRightNavBarHeight;
 					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
 					hingeRect.top = hingeRect.top - mStatusBarHeight
 					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -1,12 +1,16 @@
 package com.microsoft.reactnativedualscreen.dualscreen
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
 import android.graphics.Rect
+import android.os.Build
 import android.util.DisplayMetrics
-import android.view.View
-import android.view.WindowManager
-import android.view.Surface
-import android.view.Window
+import android.view.*
+import androidx.annotation.RequiresApi
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Arguments.createMap
 import com.facebook.react.bridge.LifecycleEventListener
@@ -36,62 +40,46 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 				Rect(0, 0, 0, 0)
 			} else boundings[0]
 		}
-	private val isStatusBarVisible: Boolean
-		get() {
-			val rectangle = Rect()
-			val window: Window? = currentActivity?.window;
-			window?.decorView?.getWindowVisibleDisplayFrame(rectangle)
-			val statusBarHeight = rectangle.top
-			return statusBarHeight != 0
-		}
+
 	private val mStatusBarHeight: Int
+		@RequiresApi(Build.VERSION_CODES.M)
 		get() {
-			var statusBarHeight: Int = 0;
-			if(isStatusBarVisible)
-			{
-				val resourceId: Int = reactApplicationContext.resources.getIdentifier("status_bar_height", "dimen", "android")
-				if (resourceId > 0) {
-					statusBarHeight = reactApplicationContext.resources.getDimensionPixelSize(resourceId)
-				}
-				return statusBarHeight;
-			}
-			return statusBarHeight;
+
+			val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetTop
+			return stableInsetTop ?: 0
 		}
 
 	private val mNavigationBarHeight: Int
+		@RequiresApi(Build.VERSION_CODES.M)
 		get() {
-			val rectangle = Rect()
-			val displayMetrics = DisplayMetrics()
-			currentActivity?.window?.decorView?.getWindowVisibleDisplayFrame(rectangle)
-			currentActivity?.windowManager?.defaultDisplay?.getRealMetrics(displayMetrics);
-			return displayMetrics.heightPixels - (rectangle.top + rectangle.height());
+			val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetBottom
+			return stableInsetBottom ?: 0
 		}
 
 	private val mNavigationBarWidth: Int
+		@RequiresApi(Build.VERSION_CODES.M)
 		get() {
-			val rectangle = Rect()
-			val displayMetrics = DisplayMetrics()
-			currentActivity?.window?.decorView?.getWindowVisibleDisplayFrame(rectangle)
-			currentActivity?.windowManager?.defaultDisplay?.getRealMetrics(displayMetrics);
-			return displayMetrics.widthPixels - (rectangle.left + rectangle.width());
+			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
+			return stableInsetRight ?: 0
 		}
 
 	private val windowRects: List<Rect>
 		get() {
 			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-			val barHeights = mStatusBarHeight + mNavigationBarHeight
+			var barHeights = mStatusBarHeight + mNavigationBarHeight;
 			val windowBounds = windowRect;
 			return if (boundings == null || boundings.size == 0) {
-				if (rotationToOrientationString(mRotation) == "portrait" || rotationToOrientationString(mRotation) == "portraitFlipped") {
+				if (rotationToOrientationString(rotation) == "portrait" || rotationToOrientationString(rotation) == "portraitFlipped") {
 					//single screen portrait
-					windowBounds.bottom = windowBounds.bottom - barHeights
+					windowBounds.bottom = windowRect.bottom - barHeights
 				} else {
 					//single screen landscape
+					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
 					windowBounds.right = windowBounds.right - mNavigationBarWidth
 				}
 				listOf(windowBounds)
 			} else {
-				val hingeRect = boundings[0]
+				val hingeRect = hinge
 				if (hingeRect.top == 0) {
 					//dual screen portrait mode
 					windowBounds.bottom = windowBounds.bottom - barHeights;
@@ -101,8 +89,8 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 				} else {
 					// dual screen landscape mode
 					windowBounds.right = windowBounds.right - mNavigationBarWidth;
-					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight;
-					hingeRect.top = hingeRect.top - mStatusBarHeight;
+					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
+					hingeRect.top = hingeRect.top - mStatusBarHeight
 					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
 					val topRect = Rect(0, 0, windowBounds.right, hingeRect.top)
 					val bottomRect = Rect(0, hingeRect.bottom, windowBounds.right, windowBounds.bottom)
@@ -117,6 +105,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 			rootView?.getDrawingRect(windowRect)
 			return windowRect
 		}
+
 	private val isDualScreenDevice = reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)
 	private var mIsSpanning: Boolean = false
 	private var mWindowRects: List<Rect> = emptyList()
@@ -145,7 +134,6 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 	override fun onHostResume() {
 		val rootView: View? = currentActivity?.window?.decorView?.rootView
 		rootView?.addOnLayoutChangeListener(onLayoutChange)
-
 	}
 
 	override fun onHostPause() {

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -56,7 +56,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 			return stableInsetBottom ?: 0
 		}
 
-	private val mRightNavBarHeight: Int
+	private val mSideNavBarHeight: Int
 		@RequiresApi(Build.VERSION_CODES.M)
 		get() {
 			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
@@ -75,7 +75,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 				} else {
 					//single screen landscape
 					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
-					windowBounds.right = windowBounds.right - mRightNavBarHeight
+					windowBounds.right = windowBounds.right - mSideNavBarHeight
 				}
 				listOf(windowBounds)
 			} else {
@@ -88,7 +88,7 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 					listOf(leftRect, rightRect)
 				} else {
 					// dual screen landscape mode
-					windowBounds.right = windowBounds.right - mRightNavBarHeight;
+					windowBounds.right = windowBounds.right - mSideNavBarHeight;
 					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
 					hingeRect.top = hingeRect.top - mStatusBarHeight
 					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;


### PR DESCRIPTION
check for single screen portrait or landscape;
subtract right rect width if in landscape;
subtract statusbarheight from windowrects.bottom in landscape;

![Screenshot_1615343385](https://user-images.githubusercontent.com/38970802/110567252-0d6d8400-8106-11eb-919f-d8e676399800.png)

![Screenshot_1615343403](https://user-images.githubusercontent.com/38970802/110567257-0f374780-8106-11eb-881d-5b6e0e52d644.png)

![Screenshot_1615343421](https://user-images.githubusercontent.com/38970802/110567262-10687480-8106-11eb-82a0-5266aae5a7c7.png)

![Screenshot_1615343436](https://user-images.githubusercontent.com/38970802/110567266-1199a180-8106-11eb-8fb9-48d09df5586b.png)

![Screenshot_1615343452](https://user-images.githubusercontent.com/38970802/110567272-12cace80-8106-11eb-860d-4239d4ab7f85.png)




