### PR TITLE
Enable Manual Payload Request in DualScreenInfo

### DIFF
--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -1,16 +1,12 @@
 package com.microsoft.reactnativedualscreen.dualscreen
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
 import android.graphics.Rect
 import android.os.Build
-import android.util.DisplayMetrics
-import android.view.*
+import android.view.Surface
+import android.view.View
+import android.view.WindowManager
 import androidx.annotation.RequiresApi
-import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.bridge.*
 import com.facebook.react.bridge.Arguments.createMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -1,14 +1,21 @@
 package com.microsoft.reactnativedualscreen.dualscreen
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
 import android.graphics.Rect
 import android.os.Build
-import android.view.Surface
-import android.view.View
-import android.view.WindowManager
+import android.util.DisplayMetrics
+import android.view.*
 import androidx.annotation.RequiresApi
-import com.facebook.react.bridge.*
+import androidx.core.view.WindowInsetsCompat
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Arguments.createMap
+import com.facebook.react.bridge.LifecycleEventListener
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.microsoft.device.display.DisplayMask
 
@@ -16,149 +23,149 @@ const val HINGE_WIDTH_KEY = "hingeWidth"
 const val IS_DUALSCREEN_DEVICE_KEY = "isDualScreenDevice"
 const val FEATURE_NAME = "com.microsoft.device.display.displaymask"
 
-class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), LifecycleEventListener {
-    private val mDisplayMask: DisplayMask?
-        get() {
-            return if (currentActivity != null && isDualScreenDevice) DisplayMask.fromResourcesRect(currentActivity) else null
-        }
-    private val rotation: Int
-        get() {
-            val wm = currentActivity?.getSystemService(Context.WINDOW_SERVICE) as WindowManager?
-            return wm?.defaultDisplay?.rotation ?: Surface.ROTATION_0
-        }
-    private val hinge: Rect
-        get() {
-            val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-            return if (boundings == null || boundings.size == 0) {
-                Rect(0, 0, 0, 0)
-            } else boundings[0]
-        }
+class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), LifecycleEventListener  {
+	private val mDisplayMask: DisplayMask?
+		get() {
+			return if(currentActivity != null && isDualScreenDevice) DisplayMask.fromResourcesRect(currentActivity) else null
+		}
+	private val rotation: Int
+		get() {
+			val wm = currentActivity?.getSystemService(Context.WINDOW_SERVICE) as WindowManager?
+			return wm?.defaultDisplay?.rotation ?: Surface.ROTATION_0
+		}
+	private val hinge: Rect
+		get() {
+			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
+			return if (boundings == null || boundings.size == 0) {
+				Rect(0, 0, 0, 0)
+			} else boundings[0]
+		}
 
-    private val mStatusBarHeight: Int
-        @RequiresApi(Build.VERSION_CODES.M)
-        get() {
+	private val mStatusBarHeight: Int
+		@RequiresApi(Build.VERSION_CODES.M)
+		get() {
 
-            val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetTop
-            return stableInsetTop ?: 0
-        }
+			val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetTop
+			return stableInsetTop ?: 0
+		}
 
-    private val mBottomNavBarHeight: Int
-        @RequiresApi(Build.VERSION_CODES.M)
-        get() {
-            val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetBottom
-            return stableInsetBottom ?: 0
-        }
+	private val mBottomNavBarHeight: Int
+		@RequiresApi(Build.VERSION_CODES.M)
+		get() {
+			val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetBottom
+			return stableInsetBottom ?: 0
+		}
 
-    private val mSideNavBarHeight: Int
-        @RequiresApi(Build.VERSION_CODES.M)
-        get() {
-            val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
-            return stableInsetRight ?: 0
-        }
+	private val mSideNavBarHeight: Int
+		@RequiresApi(Build.VERSION_CODES.M)
+		get() {
+			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
+			return stableInsetRight ?: 0
+		}
 
-    private val windowRects: List<Rect>
-        get() {
-            val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-            var barHeights = mStatusBarHeight + mBottomNavBarHeight;
-            val windowBounds = windowRect;
-            return if (boundings == null || boundings.size == 0) {
-                if (rotationToOrientationString(rotation) == "portrait" || rotationToOrientationString(rotation) == "portraitFlipped") {
-                    //single screen portrait
-                    windowBounds.bottom = windowRect.bottom - barHeights
-                } else {
-                    //single screen landscape
-                    windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
-                    windowBounds.right = windowBounds.right - mSideNavBarHeight
-                }
-                listOf(windowBounds)
-            } else {
-                val hingeRect = hinge
-                if (hingeRect.top == 0) {
-                    //dual screen portrait mode
-                    windowBounds.bottom = windowBounds.bottom - barHeights;
-                    val leftRect = Rect(0, 0, hingeRect.left, windowBounds.bottom)
-                    val rightRect = Rect(hingeRect.right, 0, windowBounds.right, windowBounds.bottom)
-                    listOf(leftRect, rightRect)
-                } else {
-                    // dual screen landscape mode
-                    windowBounds.right = windowBounds.right - mSideNavBarHeight;
-                    hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
-                    hingeRect.top = hingeRect.top - mStatusBarHeight
-                    windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
-                    val topRect = Rect(0, 0, windowBounds.right, hingeRect.top)
-                    val bottomRect = Rect(0, hingeRect.bottom, windowBounds.right, windowBounds.bottom)
-                    listOf(topRect, bottomRect)
-                }
-            }
-        }
-    private val windowRect: Rect
-        get() {
-            val windowRect = Rect()
-            val rootView: View? = currentActivity?.window?.decorView?.rootView
-            rootView?.getDrawingRect(windowRect)
-            return windowRect
-        }
+	private val windowRects: List<Rect>
+		get() {
+			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
+			var barHeights = mStatusBarHeight + mBottomNavBarHeight;
+			val windowBounds = windowRect;
+			return if (boundings == null || boundings.size == 0) {
+				if (rotationToOrientationString(rotation) == "portrait" || rotationToOrientationString(rotation) == "portraitFlipped") {
+					//single screen portrait
+					windowBounds.bottom = windowRect.bottom - barHeights
+				} else {
+					//single screen landscape
+					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
+					windowBounds.right = windowBounds.right - mSideNavBarHeight
+				}
+				listOf(windowBounds)
+			} else {
+				val hingeRect = hinge
+				if (hingeRect.top == 0) {
+					//dual screen portrait mode
+					windowBounds.bottom = windowBounds.bottom - barHeights;
+					val leftRect = Rect(0, 0, hingeRect.left, windowBounds.bottom)
+					val rightRect = Rect(hingeRect.right, 0, windowBounds.right, windowBounds.bottom)
+					listOf(leftRect, rightRect)
+				} else {
+					// dual screen landscape mode
+					windowBounds.right = windowBounds.right - mSideNavBarHeight;
+					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
+					hingeRect.top = hingeRect.top - mStatusBarHeight
+					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
+					val topRect = Rect(0, 0, windowBounds.right, hingeRect.top)
+					val bottomRect = Rect(0, hingeRect.bottom, windowBounds.right, windowBounds.bottom)
+					listOf(topRect, bottomRect)
+				}
+			}
+		}
+	private val windowRect: Rect
+		get() {
+			val windowRect = Rect()
+			val rootView: View? = currentActivity?.window?.decorView?.rootView
+			rootView?.getDrawingRect(windowRect)
+			return windowRect
+		}
 
-    private val isDualScreenDevice = reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)
-    private var mIsSpanning: Boolean = false
-    private var mWindowRects: List<Rect> = emptyList()
-    private var mRotation: Int = Surface.ROTATION_0
+	private val isDualScreenDevice = reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)
+	private var mIsSpanning: Boolean = false
+	private var mWindowRects: List<Rect> = emptyList()
+	private var mRotation: Int = Surface.ROTATION_0
 
-    private val onLayoutChange = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-        emitUpdateStateEvent()
-    }
+	private val onLayoutChange = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+		emitUpdateStateEvent()
+	}
 
-    override fun getName() = "DualScreenInfo"
+	override fun getName() = "DualScreenInfo"
 
-    override fun initialize() {
-        super.initialize()
-        reactApplicationContext.addLifecycleEventListener(this)
-        emitUpdateStateEvent()
-    }
+	override fun initialize() {
+		super.initialize()
+		reactApplicationContext.addLifecycleEventListener(this)
+		emitUpdateStateEvent()
+	}
 
-    override fun getConstants(): Map<String, Any>? {
+	override fun getConstants(): Map<String, Any>? {
         val constants: MutableMap<String, Any> = HashMap()
-        constants[HINGE_WIDTH_KEY] = 34
-        constants[IS_DUALSCREEN_DEVICE_KEY] = isDualScreenDevice
+    	constants[HINGE_WIDTH_KEY] = 34
+		constants[IS_DUALSCREEN_DEVICE_KEY] = isDualScreenDevice
 
-        return constants
+    	return constants
     }
 
-    override fun onHostResume() {
-        val rootView: View? = currentActivity?.window?.decorView?.rootView
-        rootView?.addOnLayoutChangeListener(onLayoutChange)
-    }
+	override fun onHostResume() {
+		val rootView: View? = currentActivity?.window?.decorView?.rootView
+		rootView?.addOnLayoutChangeListener(onLayoutChange)
+	}
 
-    override fun onHostPause() {
-        val rootView: View? = currentActivity?.window?.decorView?.rootView
-        rootView?.removeOnLayoutChangeListener(onLayoutChange)
-    }
+	override fun onHostPause() {
+		val rootView: View? = currentActivity?.window?.decorView?.rootView
+		rootView?.removeOnLayoutChangeListener(onLayoutChange)
+	}
 
-    override fun onHostDestroy() {}
+	override fun onHostDestroy() {}
 
-    /**
-     * Resolving a promise detecting if device is in Dual modes
-     */
-    private fun isSpanning(): Boolean {
-        if (windowRect.width() > 0 && windowRect.height() > 0) {
-            return hinge.intersect(windowRect)
-        }
+	/**
+	 * Resolving a promise detecting if device is in Dual modes
+	 */
+	private fun isSpanning(): Boolean {
+		if (windowRect.width() > 0 && windowRect.height() > 0) {
+			return hinge.intersect(windowRect)
+		}
 
-        return false
-    }
+		return false
+	}
 
-    private fun rotationToOrientationString(rotation: Int): String {
-        if (rotation == Surface.ROTATION_0) return "portrait"
-        if (rotation == Surface.ROTATION_90) return "landscape"
-        if (rotation == Surface.ROTATION_180) return "portraitFlipped"
-        assert(rotation == Surface.ROTATION_270)
-        return "landscapeFlipped"
-    }
+	private fun rotationToOrientationString(rotation : Int) : String {
+		if (rotation == Surface.ROTATION_0) return "portrait"
+		if (rotation == Surface.ROTATION_90) return "landscape"
+		if (rotation == Surface.ROTATION_180) return "portraitFlipped"
+		assert(rotation == Surface.ROTATION_270)
+		return "landscapeFlipped"
+	}
 
-    private fun convertPixelsToDp(px: Int): Double {
-        val metrics = reactApplicationContext.resources.displayMetrics
-        return (px.toDouble() / (metrics.density))
-    }
+	private fun convertPixelsToDp(px: Int): Double {
+		val metrics = reactApplicationContext.resources.displayMetrics
+		return (px.toDouble() / (metrics.density))
+	}
 
     @ReactMethod
     fun getPayload(promise: Promise) {
@@ -184,36 +191,36 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
         }
     }
 
-    private fun emitUpdateStateEvent() {
-        if (reactApplicationContext.hasActiveCatalystInstance()) {
-            // Don't emit an event to JS if the dimensions haven't changed
-            val isSpanning = isSpanning()
-            val newWindowRects = windowRects
-            val newRotation = rotation
-            if (mIsSpanning != isSpanning || mWindowRects != newWindowRects || mRotation != newRotation) {
-                mIsSpanning = isSpanning
-                mWindowRects = newWindowRects
-                mRotation = newRotation
+	private fun emitUpdateStateEvent() {
+		if (reactApplicationContext.hasActiveCatalystInstance()) {
+			// Don't emit an event to JS if the dimensions haven't changed
+			val isSpanning = isSpanning()
+			val newWindowRects = windowRects
+			val newRotation = rotation
+			if (mIsSpanning != isSpanning || mWindowRects != newWindowRects || mRotation != newRotation) {
+				mIsSpanning = isSpanning
+				mWindowRects = newWindowRects
+				mRotation = newRotation
 
-                val params = createMap()
-                val windowRectsArray = Arguments.createArray()
+				val params = createMap()
+				val windowRectsArray = Arguments.createArray()
 
-                windowRects.forEach {
-                    val rectMap = createMap()
-                    rectMap.putDouble("width", convertPixelsToDp(it.right - it.left))
-                    rectMap.putDouble("height", convertPixelsToDp(it.bottom - it.top))
-                    rectMap.putDouble("x", convertPixelsToDp(it.left))
-                    rectMap.putDouble("y", convertPixelsToDp(it.top))
-                    windowRectsArray.pushMap(rectMap)
-                }
+				windowRects.forEach {
+					val rectMap = createMap()
+					rectMap.putDouble("width", convertPixelsToDp(it.right - it.left))
+					rectMap.putDouble("height",  convertPixelsToDp(it.bottom - it.top))
+					rectMap.putDouble("x", convertPixelsToDp(it.left))
+					rectMap.putDouble("y", convertPixelsToDp(it.top))
+					windowRectsArray.pushMap(rectMap)
+				}
 
-                params.putBoolean("isSpanning", isSpanning)
-                params.putArray("windowRects", windowRectsArray)
-                params.putString("orientation", rotationToOrientationString(mRotation))
-                reactApplicationContext
-                        .getJSModule(RCTDeviceEventEmitter::class.java)
-                        .emit("didUpdateSpanning", params)
-            }
-        }
-    }
+				params.putBoolean("isSpanning", isSpanning)
+				params.putArray("windowRects", windowRectsArray)
+				params.putString("orientation", rotationToOrientationString(mRotation))
+				reactApplicationContext
+						.getJSModule(RCTDeviceEventEmitter::class.java)
+						.emit("didUpdateSpanning", params)
+			}
+		}
+	}
 }

--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -11,11 +11,8 @@ import android.util.DisplayMetrics
 import android.view.*
 import androidx.annotation.RequiresApi
 import androidx.core.view.WindowInsetsCompat
-import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.*
 import com.facebook.react.bridge.Arguments.createMap
-import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.microsoft.device.display.DisplayMask
 
@@ -23,180 +20,204 @@ const val HINGE_WIDTH_KEY = "hingeWidth"
 const val IS_DUALSCREEN_DEVICE_KEY = "isDualScreenDevice"
 const val FEATURE_NAME = "com.microsoft.device.display.displaymask"
 
-class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), LifecycleEventListener  {
-	private val mDisplayMask: DisplayMask?
-		get() {
-			return if(currentActivity != null && isDualScreenDevice) DisplayMask.fromResourcesRect(currentActivity) else null
-		}
-	private val rotation: Int
-		get() {
-			val wm = currentActivity?.getSystemService(Context.WINDOW_SERVICE) as WindowManager?
-			return wm?.defaultDisplay?.rotation ?: Surface.ROTATION_0
-		}
-	private val hinge: Rect
-		get() {
-			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-			return if (boundings == null || boundings.size == 0) {
-				Rect(0, 0, 0, 0)
-			} else boundings[0]
-		}
+class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), LifecycleEventListener {
+    private val mDisplayMask: DisplayMask?
+        get() {
+            return if (currentActivity != null && isDualScreenDevice) DisplayMask.fromResourcesRect(currentActivity) else null
+        }
+    private val rotation: Int
+        get() {
+            val wm = currentActivity?.getSystemService(Context.WINDOW_SERVICE) as WindowManager?
+            return wm?.defaultDisplay?.rotation ?: Surface.ROTATION_0
+        }
+    private val hinge: Rect
+        get() {
+            val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
+            return if (boundings == null || boundings.size == 0) {
+                Rect(0, 0, 0, 0)
+            } else boundings[0]
+        }
 
-	private val mStatusBarHeight: Int
-		@RequiresApi(Build.VERSION_CODES.M)
-		get() {
+    private val mStatusBarHeight: Int
+        @RequiresApi(Build.VERSION_CODES.M)
+        get() {
 
-			val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetTop
-			return stableInsetTop ?: 0
-		}
+            val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetTop
+            return stableInsetTop ?: 0
+        }
 
-	private val mBottomNavBarHeight: Int
-		@RequiresApi(Build.VERSION_CODES.M)
-		get() {
-			val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetBottom
-			return stableInsetBottom ?: 0
-		}
+    private val mBottomNavBarHeight: Int
+        @RequiresApi(Build.VERSION_CODES.M)
+        get() {
+            val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetBottom
+            return stableInsetBottom ?: 0
+        }
 
-	private val mSideNavBarHeight: Int
-		@RequiresApi(Build.VERSION_CODES.M)
-		get() {
-			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
-			return stableInsetRight ?: 0
-		}
+    private val mSideNavBarHeight: Int
+        @RequiresApi(Build.VERSION_CODES.M)
+        get() {
+            val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.stableInsetRight
+            return stableInsetRight ?: 0
+        }
 
-	private val windowRects: List<Rect>
-		get() {
-			val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
-			var barHeights = mStatusBarHeight + mBottomNavBarHeight;
-			val windowBounds = windowRect;
-			return if (boundings == null || boundings.size == 0) {
-				if (rotationToOrientationString(rotation) == "portrait" || rotationToOrientationString(rotation) == "portraitFlipped") {
-					//single screen portrait
-					windowBounds.bottom = windowRect.bottom - barHeights
-				} else {
-					//single screen landscape
-					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
-					windowBounds.right = windowBounds.right - mSideNavBarHeight
-				}
-				listOf(windowBounds)
-			} else {
-				val hingeRect = hinge
-				if (hingeRect.top == 0) {
-					//dual screen portrait mode
-					windowBounds.bottom = windowBounds.bottom - barHeights;
-					val leftRect = Rect(0, 0, hingeRect.left, windowBounds.bottom)
-					val rightRect = Rect(hingeRect.right, 0, windowBounds.right, windowBounds.bottom)
-					listOf(leftRect, rightRect)
-				} else {
-					// dual screen landscape mode
-					windowBounds.right = windowBounds.right - mSideNavBarHeight;
-					hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
-					hingeRect.top = hingeRect.top - mStatusBarHeight
-					windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
-					val topRect = Rect(0, 0, windowBounds.right, hingeRect.top)
-					val bottomRect = Rect(0, hingeRect.bottom, windowBounds.right, windowBounds.bottom)
-					listOf(topRect, bottomRect)
-				}
-			}
-		}
-	private val windowRect: Rect
-		get() {
-			val windowRect = Rect()
-			val rootView: View? = currentActivity?.window?.decorView?.rootView
-			rootView?.getDrawingRect(windowRect)
-			return windowRect
-		}
+    private val windowRects: List<Rect>
+        get() {
+            val boundings = mDisplayMask?.getBoundingRectsForRotation(rotation)
+            var barHeights = mStatusBarHeight + mBottomNavBarHeight;
+            val windowBounds = windowRect;
+            return if (boundings == null || boundings.size == 0) {
+                if (rotationToOrientationString(rotation) == "portrait" || rotationToOrientationString(rotation) == "portraitFlipped") {
+                    //single screen portrait
+                    windowBounds.bottom = windowRect.bottom - barHeights
+                } else {
+                    //single screen landscape
+                    windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
+                    windowBounds.right = windowBounds.right - mSideNavBarHeight
+                }
+                listOf(windowBounds)
+            } else {
+                val hingeRect = hinge
+                if (hingeRect.top == 0) {
+                    //dual screen portrait mode
+                    windowBounds.bottom = windowBounds.bottom - barHeights;
+                    val leftRect = Rect(0, 0, hingeRect.left, windowBounds.bottom)
+                    val rightRect = Rect(hingeRect.right, 0, windowBounds.right, windowBounds.bottom)
+                    listOf(leftRect, rightRect)
+                } else {
+                    // dual screen landscape mode
+                    windowBounds.right = windowBounds.right - mSideNavBarHeight;
+                    hingeRect.bottom = hingeRect.bottom - mStatusBarHeight
+                    hingeRect.top = hingeRect.top - mStatusBarHeight
+                    windowBounds.bottom = windowBounds.bottom - mStatusBarHeight;
+                    val topRect = Rect(0, 0, windowBounds.right, hingeRect.top)
+                    val bottomRect = Rect(0, hingeRect.bottom, windowBounds.right, windowBounds.bottom)
+                    listOf(topRect, bottomRect)
+                }
+            }
+        }
+    private val windowRect: Rect
+        get() {
+            val windowRect = Rect()
+            val rootView: View? = currentActivity?.window?.decorView?.rootView
+            rootView?.getDrawingRect(windowRect)
+            return windowRect
+        }
 
-	private val isDualScreenDevice = reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)
-	private var mIsSpanning: Boolean = false
-	private var mWindowRects: List<Rect> = emptyList()
-	private var mRotation: Int = Surface.ROTATION_0
+    private val isDualScreenDevice = reactApplicationContext.packageManager.hasSystemFeature(FEATURE_NAME)
+    private var mIsSpanning: Boolean = false
+    private var mWindowRects: List<Rect> = emptyList()
+    private var mRotation: Int = Surface.ROTATION_0
 
-	private val onLayoutChange = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-		emitUpdateStateEvent()
-	}
-
-	override fun getName() = "DualScreenInfo"
-
-	override fun initialize() {
-		super.initialize()
-		reactApplicationContext.addLifecycleEventListener(this)
-		emitUpdateStateEvent()
-	}
-
-	override fun getConstants(): Map<String, Any>? {
-        val constants: MutableMap<String, Any> = HashMap()
-    	constants[HINGE_WIDTH_KEY] = 34
-		constants[IS_DUALSCREEN_DEVICE_KEY] = isDualScreenDevice
-
-    	return constants
+    private val onLayoutChange = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+        emitUpdateStateEvent()
     }
 
-	override fun onHostResume() {
-		val rootView: View? = currentActivity?.window?.decorView?.rootView
-		rootView?.addOnLayoutChangeListener(onLayoutChange)
-	}
+    override fun getName() = "DualScreenInfo"
 
-	override fun onHostPause() {
-		val rootView: View? = currentActivity?.window?.decorView?.rootView
-		rootView?.removeOnLayoutChangeListener(onLayoutChange)
-	}
+    override fun initialize() {
+        super.initialize()
+        reactApplicationContext.addLifecycleEventListener(this)
+        emitUpdateStateEvent()
+    }
 
-	override fun onHostDestroy() {}
+    override fun getConstants(): Map<String, Any>? {
+        val constants: MutableMap<String, Any> = HashMap()
+        constants[HINGE_WIDTH_KEY] = 34
+        constants[IS_DUALSCREEN_DEVICE_KEY] = isDualScreenDevice
 
-	/**
-	 * Resolving a promise detecting if device is in Dual modes
-	 */
-	private fun isSpanning(): Boolean {
-		if (windowRect.width() > 0 && windowRect.height() > 0) {
-			return hinge.intersect(windowRect)
-		}
+        return constants
+    }
 
-		return false
-	}
+    override fun onHostResume() {
+        val rootView: View? = currentActivity?.window?.decorView?.rootView
+        rootView?.addOnLayoutChangeListener(onLayoutChange)
+    }
 
-	private fun rotationToOrientationString(rotation : Int) : String {
-		if (rotation == Surface.ROTATION_0) return "portrait"
-		if (rotation == Surface.ROTATION_90) return "landscape"
-		if (rotation == Surface.ROTATION_180) return "portraitFlipped"
-		assert(rotation == Surface.ROTATION_270)
-		return "landscapeFlipped"
-	}
+    override fun onHostPause() {
+        val rootView: View? = currentActivity?.window?.decorView?.rootView
+        rootView?.removeOnLayoutChangeListener(onLayoutChange)
+    }
 
-	private fun convertPixelsToDp(px: Int): Double {
-		val metrics = reactApplicationContext.resources.displayMetrics
-		return (px.toDouble() / (metrics.density))
-	}
+    override fun onHostDestroy() {}
 
-	private fun emitUpdateStateEvent() {
-		if (reactApplicationContext.hasActiveCatalystInstance()) {
-			// Don't emit an event to JS if the dimensions haven't changed
-			val isSpanning = isSpanning()
-			val newWindowRects = windowRects
-			val newRotation = rotation
-			if (mIsSpanning != isSpanning || mWindowRects != newWindowRects || mRotation != newRotation) {
-				mIsSpanning = isSpanning
-				mWindowRects = newWindowRects
-				mRotation = newRotation
+    /**
+     * Resolving a promise detecting if device is in Dual modes
+     */
+    private fun isSpanning(): Boolean {
+        if (windowRect.width() > 0 && windowRect.height() > 0) {
+            return hinge.intersect(windowRect)
+        }
 
-				val params = createMap()
-				val windowRectsArray = Arguments.createArray()
+        return false
+    }
 
-				windowRects.forEach {
-					val rectMap = createMap()
-					rectMap.putDouble("width", convertPixelsToDp(it.right - it.left))
-					rectMap.putDouble("height",  convertPixelsToDp(it.bottom - it.top))
-					rectMap.putDouble("x", convertPixelsToDp(it.left))
-					rectMap.putDouble("y", convertPixelsToDp(it.top))
-					windowRectsArray.pushMap(rectMap)
-				}
+    private fun rotationToOrientationString(rotation: Int): String {
+        if (rotation == Surface.ROTATION_0) return "portrait"
+        if (rotation == Surface.ROTATION_90) return "landscape"
+        if (rotation == Surface.ROTATION_180) return "portraitFlipped"
+        assert(rotation == Surface.ROTATION_270)
+        return "landscapeFlipped"
+    }
 
-				params.putBoolean("isSpanning", isSpanning)
-				params.putArray("windowRects", windowRectsArray)
-				params.putString("orientation", rotationToOrientationString(mRotation))
-				reactApplicationContext
-						.getJSModule(RCTDeviceEventEmitter::class.java)
-						.emit("didUpdateSpanning", params)
-			}
-		}
-	}
+    private fun convertPixelsToDp(px: Int): Double {
+        val metrics = reactApplicationContext.resources.displayMetrics
+        return (px.toDouble() / (metrics.density))
+    }
+
+    @ReactMethod
+    fun getPayload(promise: Promise) {
+        if (reactApplicationContext.hasActiveCatalystInstance()) {
+            val isSpanning = isSpanning()
+
+            val params = createMap()
+            val windowRectsArray = Arguments.createArray()
+
+            windowRects.forEach {
+                val rectMap = createMap()
+                rectMap.putDouble("width", convertPixelsToDp(it.right - it.left))
+                rectMap.putDouble("height", convertPixelsToDp(it.bottom - it.top))
+                rectMap.putDouble("x", convertPixelsToDp(it.left))
+                rectMap.putDouble("y", convertPixelsToDp(it.top))
+                windowRectsArray.pushMap(rectMap)
+            }
+
+            params.putBoolean("isSpanning", isSpanning)
+            params.putArray("windowRects", windowRectsArray)
+            params.putString("orientation", rotationToOrientationString(rotation))
+            promise.resolve(params);
+        }
+    }
+
+    private fun emitUpdateStateEvent() {
+        if (reactApplicationContext.hasActiveCatalystInstance()) {
+            // Don't emit an event to JS if the dimensions haven't changed
+            val isSpanning = isSpanning()
+            val newWindowRects = windowRects
+            val newRotation = rotation
+            if (mIsSpanning != isSpanning || mWindowRects != newWindowRects || mRotation != newRotation) {
+                mIsSpanning = isSpanning
+                mWindowRects = newWindowRects
+                mRotation = newRotation
+
+                val params = createMap()
+                val windowRectsArray = Arguments.createArray()
+
+                windowRects.forEach {
+                    val rectMap = createMap()
+                    rectMap.putDouble("width", convertPixelsToDp(it.right - it.left))
+                    rectMap.putDouble("height", convertPixelsToDp(it.bottom - it.top))
+                    rectMap.putDouble("x", convertPixelsToDp(it.left))
+                    rectMap.putDouble("y", convertPixelsToDp(it.top))
+                    windowRectsArray.pushMap(rectMap)
+                }
+
+                params.putBoolean("isSpanning", isSpanning)
+                params.putArray("windowRects", windowRectsArray)
+                params.putString("orientation", rotationToOrientationString(mRotation))
+                reactApplicationContext
+                        .getJSModule(RCTDeviceEventEmitter::class.java)
+                        .emit("didUpdateSpanning", params)
+            }
+        }
+    }
 }

--- a/dualscreeninfo/package.json
+++ b/dualscreeninfo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-dualscreeninfo",
   "title": "React Native DualScreenInfo",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "React Native package for dual screen devices support (Surface Duo)",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",

--- a/dualscreeninfo/src/dualscreeninfo/index.ts
+++ b/dualscreeninfo/src/dualscreeninfo/index.ts
@@ -3,85 +3,84 @@
  * Licensed under the MIT License.
  */
 
- import { DualScreenInfoEvent, DualScreenInfoPayload, SpannedChangeHandler, WindowRect, DeviceOrientation } from "../types";
- import { EmitterSubscription, NativeEventEmitter, NativeModules } from "react-native";
- 
- declare module 'react-native' {
-	 namespace NativeModules {
-		 export interface DualScreenInfo {
-			 isDualScreenDevice: boolean
-			 hingeWidth: number
-			 orientation: DeviceOrientation
-			 getPayload(): Promise<DualScreenInfoPayload>
-		 }
-	 }
- }
- 
- export interface ExposedNativeMethods {
-	 addEventListener: (
-		 type: DualScreenInfoEvent,
-		 handler: SpannedChangeHandler
-	 ) => void;
-	 removeEventListener: (
-		 type: DualScreenInfoEvent,
-		 handler: SpannedChangeHandler
-	 ) => void;
- }
- 
- interface IDualScreenInfoModule extends ExposedNativeMethods {
-	 isDualScreenDevice: boolean;
-	 hingeWidth: number;
-	 isSpanning: boolean;
-	 windowRects: WindowRect[];
-	 orientation: DeviceOrientation;
- }
- 
- class RNDualScreenInfoModule implements IDualScreenInfoModule {
-	 private mIsSpanning: boolean = false;
-	 private mWindowRects: WindowRect[] = [];
-	 private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
-	 private eventEmitter: NativeEventEmitter = new NativeEventEmitter(NativeModules.DualScreenInfo);
- 
-	 constructor() {
-		 this.eventEmitter.addListener('didUpdateSpanning', (update: DualScreenInfoPayload) => {
-			 this.mIsSpanning = update.isSpanning;
-			 this.mWindowRects = update.windowRects;
-			 this.mOrientation = update.orientation;
-		 });
-	 }
- 
-	 addEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): EmitterSubscription {
-		 return this.eventEmitter.addListener(type, handler);
-	 }
- 
-	 removeEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): void {
-		 this.eventEmitter.removeListener(type, handler);
-	 }
- 
-	 getPayload(): Promise<DualScreenInfoPayload> {
-		 return this.getPayload();
-	 }
- 
-	 get isDualScreenDevice(): boolean {
-		 return NativeModules.DualScreenInfo.isDualScreenDevice;
-	 }
- 
-	 get hingeWidth(): number {
-		 return NativeModules.DualScreenInfo.hingeWidth;
-	 }
- 
-	 get isSpanning(): boolean {
-		 return this.mIsSpanning;
-	 }
- 
-	 get windowRects(): WindowRect[] {
-		 return this.mWindowRects;
-	 };
- 
-	 get orientation(): DeviceOrientation {
-		 return this.mOrientation;
-	 }
- }
- 
- export const DualScreenInfo = new RNDualScreenInfoModule();
- 
+import { DualScreenInfoEvent, DualScreenInfoPayload, SpannedChangeHandler, WindowRect, DeviceOrientation } from "../types";
+import { EmitterSubscription, NativeEventEmitter, NativeModules } from "react-native";
+
+declare module 'react-native' {
+	namespace NativeModules {
+		export interface DualScreenInfo {
+			isDualScreenDevice: boolean
+			hingeWidth: number
+			orientation: DeviceOrientation
+			getPayload(): Promise<DualScreenInfoPayload>
+		}
+	}
+}
+
+export interface ExposedNativeMethods {
+	addEventListener: (
+		type: DualScreenInfoEvent,
+		handler: SpannedChangeHandler
+	) => void;
+	removeEventListener: (
+		type: DualScreenInfoEvent,
+		handler: SpannedChangeHandler
+	) => void;
+}
+
+interface IDualScreenInfoModule extends ExposedNativeMethods {
+	isDualScreenDevice: boolean;
+	hingeWidth: number;
+	isSpanning: boolean;
+	windowRects: WindowRect[];
+	orientation: DeviceOrientation;
+}
+
+class RNDualScreenInfoModule implements IDualScreenInfoModule {
+	private mIsSpanning: boolean = false;
+	private mWindowRects: WindowRect[] = [];
+	private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
+	private eventEmitter: NativeEventEmitter = new NativeEventEmitter(NativeModules.DualScreenInfo);
+
+	constructor() {
+		this.eventEmitter.addListener('didUpdateSpanning', (update: DualScreenInfoPayload) => {
+			this.mIsSpanning = update.isSpanning;
+			this.mWindowRects = update.windowRects;
+			this.mOrientation = update.orientation;
+		});
+	}
+
+	addEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): EmitterSubscription {
+		return this.eventEmitter.addListener(type, handler);
+	}
+
+	removeEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): void {
+		this.eventEmitter.removeListener(type, handler);
+	}
+
+	getPayload(): Promise<DualScreenInfoPayload> {
+		return this.getPayload();
+	}
+
+	get isDualScreenDevice(): boolean {
+		return NativeModules.DualScreenInfo.isDualScreenDevice;
+	}
+
+	get hingeWidth(): number {
+		return NativeModules.DualScreenInfo.hingeWidth;
+	}
+
+	get isSpanning(): boolean {
+		return this.mIsSpanning;
+	}
+
+	get windowRects(): WindowRect[] {
+		return this.mWindowRects;
+	};
+
+	get orientation(): DeviceOrientation {
+		return this.mOrientation;
+	}
+}
+
+export const DualScreenInfo = new RNDualScreenInfoModule();

--- a/dualscreeninfo/src/dualscreeninfo/index.ts
+++ b/dualscreeninfo/src/dualscreeninfo/index.ts
@@ -3,105 +3,85 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DualScreenInfoEvent,
-	DualScreenInfoPayload,
-	SpannedChangeHandler,
-	WindowRect,
-	DeviceOrientation,
-} from '../types';
-import {
-	EmitterSubscription,
-	NativeEventEmitter,
-	NativeModules,
-} from 'react-native';
-
-declare module 'react-native' {
-	namespace NativeModules {
-		export interface DualScreenInfo {
-			isDualScreenDevice: boolean
-			hingeWidth: number
-			orientation: DeviceOrientation
-			getPayload(): Promise<DualScreenInfoPayload>
-		}
-	}
-}
-
-export interface ExposedNativeMethods {
-	addEventListener: (
-		type: DualScreenInfoEvent,
-		handler: SpannedChangeHandler
-	) => void;
-	removeEventListener: (
-		type: DualScreenInfoEvent,
-		handler: SpannedChangeHandler
-	) => void;
-}
-
-interface IDualScreenInfoModule extends ExposedNativeMethods {
-	isDualScreenDevice: boolean;
-	hingeWidth: number;
-	isSpanning: boolean;
-	windowRects: WindowRect[];
-	orientation: DeviceOrientation;
-}
-
-class RNDualScreenInfoModule implements IDualScreenInfoModule {
-	private mIsSpanning: boolean = false;
-	private mWindowRects: WindowRect[] = [];
-	private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
-	private eventEmitter: NativeEventEmitter = new NativeEventEmitter(
-		NativeModules.DualScreenInfo
-	);
-
-	constructor() {
-		this.eventEmitter.addListener(
-			'didUpdateSpanning',
-			(update: DualScreenInfoPayload) => {
-				this.mIsSpanning = update.isSpanning;
-				this.mWindowRects = update.windowRects;
-				this.mOrientation = update.orientation;
-			}
-		);
-	}
-
-	addEventListener(
-		type: DualScreenInfoEvent,
-		handler: SpannedChangeHandler
-	): EmitterSubscription {
-		return this.eventEmitter.addListener(type, handler);
-	}
-
-	removeEventListener(
-		type: DualScreenInfoEvent,
-		handler: SpannedChangeHandler
-	): void {
-		this.eventEmitter.removeListener(type, handler);
-	}
-
-	getPayload(): Promise<DualScreenInfoPayload> {
-		return this.getPayload();
-	}
-
-	get isDualScreenDevice(): boolean {
-		return NativeModules.DualScreenInfo.isDualScreenDevice;
-	}
-
-	get hingeWidth(): number {
-		return NativeModules.DualScreenInfo.hingeWidth;
-	}
-
-	get isSpanning(): boolean {
-		return this.mIsSpanning;
-	}
-
-	get windowRects(): WindowRect[] {
-		return this.mWindowRects;
-	}
-
-	get orientation(): DeviceOrientation {
-		return this.mOrientation;
-	}
-}
-
-export const DualScreenInfo = new RNDualScreenInfoModule();
+ import { DualScreenInfoEvent, DualScreenInfoPayload, SpannedChangeHandler, WindowRect, DeviceOrientation } from "../types";
+ import { EmitterSubscription, NativeEventEmitter, NativeModules } from "react-native";
+ 
+ declare module 'react-native' {
+	 namespace NativeModules {
+		 export interface DualScreenInfo {
+			 isDualScreenDevice: boolean
+			 hingeWidth: number
+			 orientation: DeviceOrientation
+			 getPayload(): Promise<DualScreenInfoPayload>
+		 }
+	 }
+ }
+ 
+ export interface ExposedNativeMethods {
+	 addEventListener: (
+		 type: DualScreenInfoEvent,
+		 handler: SpannedChangeHandler
+	 ) => void;
+	 removeEventListener: (
+		 type: DualScreenInfoEvent,
+		 handler: SpannedChangeHandler
+	 ) => void;
+ }
+ 
+ interface IDualScreenInfoModule extends ExposedNativeMethods {
+	 isDualScreenDevice: boolean;
+	 hingeWidth: number;
+	 isSpanning: boolean;
+	 windowRects: WindowRect[];
+	 orientation: DeviceOrientation;
+ }
+ 
+ class RNDualScreenInfoModule implements IDualScreenInfoModule {
+	 private mIsSpanning: boolean = false;
+	 private mWindowRects: WindowRect[] = [];
+	 private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
+	 private eventEmitter: NativeEventEmitter = new NativeEventEmitter(NativeModules.DualScreenInfo);
+ 
+	 constructor() {
+		 this.eventEmitter.addListener('didUpdateSpanning', (update: DualScreenInfoPayload) => {
+			 this.mIsSpanning = update.isSpanning;
+			 this.mWindowRects = update.windowRects;
+			 this.mOrientation = update.orientation;
+		 });
+	 }
+ 
+	 addEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): EmitterSubscription {
+		 return this.eventEmitter.addListener(type, handler);
+	 }
+ 
+	 removeEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): void {
+		 this.eventEmitter.removeListener(type, handler);
+	 }
+ 
+	 getPayload(): Promise<DualScreenInfoPayload> {
+		 return this.getPayload();
+	 }
+ 
+	 get isDualScreenDevice(): boolean {
+		 return NativeModules.DualScreenInfo.isDualScreenDevice;
+	 }
+ 
+	 get hingeWidth(): number {
+		 return NativeModules.DualScreenInfo.hingeWidth;
+	 }
+ 
+	 get isSpanning(): boolean {
+		 return this.mIsSpanning;
+	 }
+ 
+	 get windowRects(): WindowRect[] {
+		 return this.mWindowRects;
+	 };
+ 
+	 get orientation(): DeviceOrientation {
+		 return this.mOrientation;
+	 }
+ }
+ 
+ export const DualScreenInfo = new RNDualScreenInfoModule();
+ 

--- a/dualscreeninfo/src/dualscreeninfo/index.ts
+++ b/dualscreeninfo/src/dualscreeninfo/index.ts
@@ -3,79 +3,105 @@
  * Licensed under the MIT License.
  */
 
-import { DualScreenInfoEvent, DualScreenInfoPayload, SpannedChangeHandler, WindowRect, DeviceOrientation } from "../types";
-import { EmitterSubscription, NativeEventEmitter, NativeModules } from "react-native";
+import {
+  DualScreenInfoEvent,
+  DualScreenInfoPayload,
+  SpannedChangeHandler,
+  WindowRect,
+  DeviceOrientation,
+} from '../types';
+import {
+  EmitterSubscription,
+  NativeEventEmitter,
+  NativeModules,
+} from 'react-native';
 
 declare module 'react-native' {
-	namespace NativeModules {
-		export interface DualScreenInfo {
-			isDualScreenDevice: boolean
-			hingeWidth: number
-			orientation: DeviceOrientation
-		}
-	}
+  namespace NativeModules {
+    export interface DualScreenInfo {
+      isDualScreenDevice: boolean;
+      hingeWidth: number;
+      orientation: DeviceOrientation;
+      getPayload(): Promise<DualScreenInfoPayload>;
+    }
+  }
 }
 
 export interface ExposedNativeMethods {
-	addEventListener: (
-		type: DualScreenInfoEvent,
-		handler: SpannedChangeHandler
-	) => void;
-	removeEventListener: (
-		type: DualScreenInfoEvent,
-		handler: SpannedChangeHandler
-	) => void;
+  addEventListener: (
+    type: DualScreenInfoEvent,
+    handler: SpannedChangeHandler
+  ) => void;
+  removeEventListener: (
+    type: DualScreenInfoEvent,
+    handler: SpannedChangeHandler
+  ) => void;
 }
 
 interface IDualScreenInfoModule extends ExposedNativeMethods {
-	isDualScreenDevice: boolean;
-	hingeWidth: number;
-	isSpanning: boolean;
-	windowRects: WindowRect[];
-	orientation: DeviceOrientation;
+  isDualScreenDevice: boolean;
+  hingeWidth: number;
+  isSpanning: boolean;
+  windowRects: WindowRect[];
+  orientation: DeviceOrientation;
 }
 
 class RNDualScreenInfoModule implements IDualScreenInfoModule {
-	private mIsSpanning: boolean = false;
-	private mWindowRects: WindowRect[] = [];
-	private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
-	private eventEmitter: NativeEventEmitter = new NativeEventEmitter(NativeModules.DualScreenInfo);
+  private mIsSpanning: boolean = false;
+  private mWindowRects: WindowRect[] = [];
+  private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
+  private eventEmitter: NativeEventEmitter = new NativeEventEmitter(
+    NativeModules.DualScreenInfo
+  );
 
-	constructor() {
-		this.eventEmitter.addListener('didUpdateSpanning', (update: DualScreenInfoPayload) => {
-			this.mIsSpanning = update.isSpanning;
-			this.mWindowRects = update.windowRects;
-			this.mOrientation = update.orientation;
-		});
-	}
+  constructor() {
+    this.eventEmitter.addListener(
+      'didUpdateSpanning',
+      (update: DualScreenInfoPayload) => {
+        this.mIsSpanning = update.isSpanning;
+        this.mWindowRects = update.windowRects;
+        this.mOrientation = update.orientation;
+      }
+    );
+  }
 
-	addEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): EmitterSubscription {
-		return this.eventEmitter.addListener(type, handler);
-	}
+  addEventListener(
+    type: DualScreenInfoEvent,
+    handler: SpannedChangeHandler
+  ): EmitterSubscription {
+    return this.eventEmitter.addListener(type, handler);
+  }
 
-	removeEventListener(type: DualScreenInfoEvent, handler: SpannedChangeHandler): void {
-		this.eventEmitter.removeListener(type, handler);
-	}
+  removeEventListener(
+    type: DualScreenInfoEvent,
+    handler: SpannedChangeHandler
+  ): void {
+    this.eventEmitter.removeListener(type, handler);
+  }
 
-	get isDualScreenDevice(): boolean {
-		return NativeModules.DualScreenInfo.isDualScreenDevice;
-	}
+  getPayload(): Promise<DualScreenInfoPayload> {
+    return this.getPayload();
+  }
 
-	get hingeWidth(): number {
-		return NativeModules.DualScreenInfo.hingeWidth;
-	}
+  get isDualScreenDevice(): boolean {
+    return NativeModules.DualScreenInfo.isDualScreenDevice;
+  }
 
-	get isSpanning(): boolean {
-		return this.mIsSpanning;
-	}
+  get hingeWidth(): number {
+    return NativeModules.DualScreenInfo.hingeWidth;
+  }
 
-	get windowRects(): WindowRect[] {
-		return this.mWindowRects;
-	};
+  get isSpanning(): boolean {
+    return this.mIsSpanning;
+  }
 
-	get orientation(): DeviceOrientation {
-		return this.mOrientation;
-	}
+  get windowRects(): WindowRect[] {
+    return this.mWindowRects;
+  }
+
+  get orientation(): DeviceOrientation {
+    return this.mOrientation;
+  }
 }
 
 export const DualScreenInfo = new RNDualScreenInfoModule();

--- a/dualscreeninfo/src/dualscreeninfo/index.ts
+++ b/dualscreeninfo/src/dualscreeninfo/index.ts
@@ -4,104 +4,104 @@
  */
 
 import {
-  DualScreenInfoEvent,
-  DualScreenInfoPayload,
-  SpannedChangeHandler,
-  WindowRect,
-  DeviceOrientation,
+	DualScreenInfoEvent,
+	DualScreenInfoPayload,
+	SpannedChangeHandler,
+	WindowRect,
+	DeviceOrientation,
 } from '../types';
 import {
-  EmitterSubscription,
-  NativeEventEmitter,
-  NativeModules,
+	EmitterSubscription,
+	NativeEventEmitter,
+	NativeModules,
 } from 'react-native';
 
 declare module 'react-native' {
-  namespace NativeModules {
-    export interface DualScreenInfo {
-      isDualScreenDevice: boolean;
-      hingeWidth: number;
-      orientation: DeviceOrientation;
-      getPayload(): Promise<DualScreenInfoPayload>;
-    }
-  }
+	namespace NativeModules {
+		export interface DualScreenInfo {
+			isDualScreenDevice: boolean
+			hingeWidth: number
+			orientation: DeviceOrientation
+			getPayload(): Promise<DualScreenInfoPayload>
+		}
+	}
 }
 
 export interface ExposedNativeMethods {
-  addEventListener: (
-    type: DualScreenInfoEvent,
-    handler: SpannedChangeHandler
-  ) => void;
-  removeEventListener: (
-    type: DualScreenInfoEvent,
-    handler: SpannedChangeHandler
-  ) => void;
+	addEventListener: (
+		type: DualScreenInfoEvent,
+		handler: SpannedChangeHandler
+	) => void;
+	removeEventListener: (
+		type: DualScreenInfoEvent,
+		handler: SpannedChangeHandler
+	) => void;
 }
 
 interface IDualScreenInfoModule extends ExposedNativeMethods {
-  isDualScreenDevice: boolean;
-  hingeWidth: number;
-  isSpanning: boolean;
-  windowRects: WindowRect[];
-  orientation: DeviceOrientation;
+	isDualScreenDevice: boolean;
+	hingeWidth: number;
+	isSpanning: boolean;
+	windowRects: WindowRect[];
+	orientation: DeviceOrientation;
 }
 
 class RNDualScreenInfoModule implements IDualScreenInfoModule {
-  private mIsSpanning: boolean = false;
-  private mWindowRects: WindowRect[] = [];
-  private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
-  private eventEmitter: NativeEventEmitter = new NativeEventEmitter(
-    NativeModules.DualScreenInfo
-  );
+	private mIsSpanning: boolean = false;
+	private mWindowRects: WindowRect[] = [];
+	private mOrientation: DeviceOrientation = DeviceOrientation.Portrait;
+	private eventEmitter: NativeEventEmitter = new NativeEventEmitter(
+		NativeModules.DualScreenInfo
+	);
 
-  constructor() {
-    this.eventEmitter.addListener(
-      'didUpdateSpanning',
-      (update: DualScreenInfoPayload) => {
-        this.mIsSpanning = update.isSpanning;
-        this.mWindowRects = update.windowRects;
-        this.mOrientation = update.orientation;
-      }
-    );
-  }
+	constructor() {
+		this.eventEmitter.addListener(
+			'didUpdateSpanning',
+			(update: DualScreenInfoPayload) => {
+				this.mIsSpanning = update.isSpanning;
+				this.mWindowRects = update.windowRects;
+				this.mOrientation = update.orientation;
+			}
+		);
+	}
 
-  addEventListener(
-    type: DualScreenInfoEvent,
-    handler: SpannedChangeHandler
-  ): EmitterSubscription {
-    return this.eventEmitter.addListener(type, handler);
-  }
+	addEventListener(
+		type: DualScreenInfoEvent,
+		handler: SpannedChangeHandler
+	): EmitterSubscription {
+		return this.eventEmitter.addListener(type, handler);
+	}
 
-  removeEventListener(
-    type: DualScreenInfoEvent,
-    handler: SpannedChangeHandler
-  ): void {
-    this.eventEmitter.removeListener(type, handler);
-  }
+	removeEventListener(
+		type: DualScreenInfoEvent,
+		handler: SpannedChangeHandler
+	): void {
+		this.eventEmitter.removeListener(type, handler);
+	}
 
-  getPayload(): Promise<DualScreenInfoPayload> {
-    return this.getPayload();
-  }
+	getPayload(): Promise<DualScreenInfoPayload> {
+		return this.getPayload();
+	}
 
-  get isDualScreenDevice(): boolean {
-    return NativeModules.DualScreenInfo.isDualScreenDevice;
-  }
+	get isDualScreenDevice(): boolean {
+		return NativeModules.DualScreenInfo.isDualScreenDevice;
+	}
 
-  get hingeWidth(): number {
-    return NativeModules.DualScreenInfo.hingeWidth;
-  }
+	get hingeWidth(): number {
+		return NativeModules.DualScreenInfo.hingeWidth;
+	}
 
-  get isSpanning(): boolean {
-    return this.mIsSpanning;
-  }
+	get isSpanning(): boolean {
+		return this.mIsSpanning;
+	}
 
-  get windowRects(): WindowRect[] {
-    return this.mWindowRects;
-  }
+	get windowRects(): WindowRect[] {
+		return this.mWindowRects;
+	}
 
-  get orientation(): DeviceOrientation {
-    return this.mOrientation;
-  }
+	get orientation(): DeviceOrientation {
+		return this.mOrientation;
+	}
 }
 
 export const DualScreenInfo = new RNDualScreenInfoModule();

--- a/twopane-navigation/package.json
+++ b/twopane-navigation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-twopane-navigation",
   "Title": "React Native TwoPane-Navigation",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "React Native package for dual screen devices navigation support (Surface Duo)",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "lodash": "*",
-    "react-native-dualscreeninfo": "^0.1.8",
+    "react-native-dualscreeninfo": "*",
     "react-redux": "*",
     "redux": "*"
   },

--- a/twopane-navigation/src/components/paneHeader/PaneHeader.tsx
+++ b/twopane-navigation/src/components/paneHeader/PaneHeader.tsx
@@ -16,6 +16,7 @@ const PaneHeader = (props: IPaneHeaderProps) => {
       {props?.leftIcon! !== undefined && (
         <Fragment>
           <TouchableOpacity
+            accessibilityLabel={'header_button'}
             style={PaneHeaderStyles.leftButton}
             onPress={() => props?.IconPress!()} //element
           >

--- a/twopane-navigation/src/components/twoPaneApp/TwoPaneApp.tsx
+++ b/twopane-navigation/src/components/twoPaneApp/TwoPaneApp.tsx
@@ -24,8 +24,13 @@ const TwoPaneApp = (props: ITwoPaneAppProps) => {
         utilityStore.pushConfig(props.config);
       }
     }
+    const getPayloadAsync = async () => {
+      const payload = await DualScreenInfo.getPayload();
+      _handleSpanningChanged(payload);
+    }
 
     utilityStore.pushIsTwoPane(DualScreenInfo.isSpanning)
+    getPayloadAsync();
     DualScreenInfo.addEventListener('didUpdateSpanning', _handleSpanningChanged);
     return () => {
       DualScreenInfo.removeEventListener('didUpdateSpanning', _handleSpanningChanged);


### PR DESCRIPTION
add getPayload method to dualscreeninfo;
expose getPayload in dualscreeninfo types;
getPayload in TwpPaneApp mount;
add accessibility label to pane header button;

This change addresses an issue with dualscreeninfo not providing any dimensions by default when the main component in twopane-navigation is mounted.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-dualscreen/pull/80)