### PR TITLE
use the correct `repository` data in `package.json`s

### DIFF
--- a/dualscreeninfo/package.json
+++ b/dualscreeninfo/package.json
@@ -18,8 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/microsoft/react-native-dualscreen.git",
-    "baseUrl": "https://github.com/microsoft/react-native-dualscreen"
+    "url": "https://github.com/microsoft/react-native-dualscreen.git",
+    "directory": "dualscreeninfo"
   },
   "keywords": [
     "react-native",

--- a/twopane-navigation/package.json
+++ b/twopane-navigation/package.json
@@ -16,8 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/microsoft/react-native-dualscreen.git",
-    "baseUrl": "https://github.com/microsoft/react-native-dualscreen"
+    "url": "https://github.com/microsoft/react-native-dualscreen.git",
+    "directory": "twopane-navigation"
   },
   "keywords": [
     "react-native",

--- a/twopaneview/package.json
+++ b/twopaneview/package.json
@@ -18,8 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/microsoft/react-native-dualscreen.git",
-    "baseUrl": "https://github.com/microsoft/react-native-dualscreen"
+    "url": "https://github.com/microsoft/react-native-dualscreen.git",
+    "directory": "twopaneview"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
This small PR updates the packages `repository` data in the `package.json`s files according to the NPM docs:
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository