### PR TITLE
Move importantForAccessibility down a level

### DIFF
--- a/twopane-navigation/package.json
+++ b/twopane-navigation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-twopane-navigation",
   "Title": "React Native TwoPane-Navigation",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "React Native package for dual screen devices navigation support (Surface Duo)",
   "react-native": "src/index.ts",
   "types": "lib/typescript/index.d.ts",

--- a/twopane-navigation/src/components/paneHeader/PaneHeader.tsx
+++ b/twopane-navigation/src/components/paneHeader/PaneHeader.tsx
@@ -16,7 +16,8 @@ const PaneHeader = (props: IPaneHeaderProps) => {
       {props?.leftIcon! !== undefined && (
         <Fragment>
           <TouchableOpacity
-            accessibilityLabel={'Open Drawer/Navigation Menu'}
+            accessibilityRole={'button'}
+            accessibilityLabel={props.buttonAccessibilityLabel ? props.buttonAccessibilityLabel : 'Go back'}
             style={PaneHeaderStyles.leftButton}
             onPress={() => props?.IconPress!()} //element
           >

--- a/twopane-navigation/src/components/paneHeaderContainer/PaneHeaderContainer.tsx
+++ b/twopane-navigation/src/components/paneHeaderContainer/PaneHeaderContainer.tsx
@@ -19,7 +19,7 @@ const PaneHeaderContainer = (props: IPaneHeaderContainerProps) => {
     const { isGoBack, screenHeader, goBack, configDefaultHeader, configDefaultHeaderText, configDefaultHeaderIcon } = props;
 
     const backActionHandler = () => {
-        if(isGoBack)
+        if(isGoBack && screenHeader?.canGoBack !== false)
         {
             goBack();
         } else{
@@ -29,7 +29,7 @@ const PaneHeaderContainer = (props: IPaneHeaderContainerProps) => {
                 onPress: () => null,
                 style: "cancel"
               },
-              { text: "YES", onPress: () => BackHandler.exitApp() }
+              { text: "Yes", onPress: () => BackHandler.exitApp() }
             ]);
         }
         return true;
@@ -39,7 +39,7 @@ const PaneHeaderContainer = (props: IPaneHeaderContainerProps) => {
 
     return (
         <View style={{ flex: 1 }}>
-            {isGoBack ? (
+            {isGoBack && screenHeader?.canGoBack !== false ? (
                 <ScreenHeader
                     style={[
                             paneHeaderContainerStyles.HeaderDefault, configDefaultHeader!

--- a/twopane-navigation/src/components/paneRenderer/PaneRenderer.tsx
+++ b/twopane-navigation/src/components/paneRenderer/PaneRenderer.tsx
@@ -163,15 +163,15 @@ const PaneRenderer = (props: IPaneRendererProps) => {
     return (
         <Fragment>
             {paneComponents.map((val: IPaneComponent) => (
-                <View
-                    importantForAccessibility={
-                        isComponentDisplayed(val)
-                            ? 'auto'
-                            : 'no-hide-descendants'
-                    }
-                    key={val.key}
-                >
-                    <View style={renderStyles(val.pane, val.extensionOptions)}>
+                <View key={val.key}>
+                    <View
+                        importantForAccessibility={
+                            isComponentDisplayed(val)
+                                ? 'auto'
+                                : 'no-hide-descendants'
+                        }
+                        style={renderStyles(val.pane, val.extensionOptions)}
+                    >
                         <View
                             style={
                                 generalStyles(

--- a/twopane-navigation/src/components/paneRenderer/PaneRenderer.tsx
+++ b/twopane-navigation/src/components/paneRenderer/PaneRenderer.tsx
@@ -25,12 +25,7 @@ interface IPaneRendererProps {
 const PaneRenderer = (props: IPaneRendererProps) => {
     const defaultConfig = getUtilityStore().config;
     const { paneComponents, paneRects, orientation } = props;
-    const paneOneComponents = paneComponents.filter(
-        (x) => x.pane === paneType.ONE
-    );
-    const paneTwoComponents = paneComponents.filter(
-        (x) => x.pane === paneType.TWO
-    );
+
     const firstPane = paneComponents[0];
     const isPaneOneExtended = () => {
         if (
@@ -138,6 +133,12 @@ const PaneRenderer = (props: IPaneRendererProps) => {
     };
 
     const isComponentDisplayed = (component: IPaneComponent) => {
+        const paneOneComponents = paneComponents.filter(
+            (x) => x.pane === paneType.ONE
+        );
+        const paneTwoComponents = paneComponents.filter(
+            (x) => x.pane === paneType.TWO
+        );
         const isTopPaneOne =
             component.pane === paneType.ONE &&
             paneOneComponents.pop()?.key === component.key;
@@ -162,68 +163,78 @@ const PaneRenderer = (props: IPaneRendererProps) => {
 
     return (
         <Fragment>
-            {paneComponents.map((val: IPaneComponent) => (
-                <View key={val.key}>
-                    <View
-                        importantForAccessibility={
-                            isComponentDisplayed(val)
-                                ? 'auto'
-                                : 'no-hide-descendants'
-                        }
-                        style={renderStyles(val.pane, val.extensionOptions)}
-                    >
+            {paneComponents.map((val: IPaneComponent) => {
+                return (
+                    <View key={val.key}>
                         <View
-                            style={
-                                generalStyles(
-                                    paneType.ONE
-                                        ? defaultConfig.onePane?.paneHeader!
-                                        : defaultConfig.twoPane?.paneHeader!
-                                ).header
+                            importantForAccessibility={
+                                isComponentDisplayed(val)
+                                    ? 'auto'
+                                    : 'no-hide-descendants'
                             }
+                            style={renderStyles(val.pane, val.extensionOptions)}
                         >
-                            <PaneHeaderContainer
-                                isGoBack={
-                                    val.pane === paneType.ONE
-                                        ? paneOneComponents.length > 1
-                                        : paneTwoComponents.length > 1
+                            <View
+                                style={
+                                    generalStyles(
+                                        paneType.ONE
+                                            ? defaultConfig.onePane?.paneHeader!
+                                            : defaultConfig.twoPane?.paneHeader!
+                                    ).header
                                 }
-                                screenHeader={val.header}
-                                goBack={() =>
-                                    val.pane === paneType.ONE
-                                        ? onePane.GoBack()
-                                        : twoPane.GoBack()
+                            >
+                                <PaneHeaderContainer
+                                    isGoBack={
+                                        val.pane === paneType.ONE
+                                            ? paneComponents.filter(
+                                                  (x) => x.pane === paneType.ONE
+                                              ).length > 1
+                                            : paneComponents.filter(
+                                                  (x) => x.pane === paneType.TWO
+                                              ).length > 1
+                                    }
+                                    screenHeader={val.header}
+                                    goBack={() =>
+                                        val.pane === paneType.ONE
+                                            ? onePane.GoBack()
+                                            : twoPane.GoBack()
+                                    }
+                                    configDefaultHeader={
+                                        val.pane === paneType.ONE
+                                            ? defaultConfig.onePane?.paneHeader!
+                                            : defaultConfig.twoPane?.paneHeader!
+                                    }
+                                    configDefaultHeaderText={
+                                        val.pane === paneType.ONE
+                                            ? defaultConfig.onePane
+                                                  ?.paneHeaderText!
+                                            : defaultConfig.twoPane
+                                                  ?.paneHeaderText!
+                                    }
+                                    configDefaultHeaderIcon={
+                                        val.pane === paneType.ONE
+                                            ? defaultConfig.onePane
+                                                  ?.paneHeaderIcon!
+                                            : defaultConfig.twoPane
+                                                  ?.paneHeaderIcon!
+                                    }
+                                />
+                            </View>
+                            <View
+                                style={
+                                    generalStyles(
+                                        paneType.ONE
+                                            ? defaultConfig.onePane?.paneHeader!
+                                            : defaultConfig.twoPane?.paneHeader!
+                                    ).body
                                 }
-                                configDefaultHeader={
-                                    val.pane === paneType.ONE
-                                        ? defaultConfig.onePane?.paneHeader!
-                                        : defaultConfig.twoPane?.paneHeader!
-                                }
-                                configDefaultHeaderText={
-                                    val.pane === paneType.ONE
-                                        ? defaultConfig.onePane?.paneHeaderText!
-                                        : defaultConfig.twoPane?.paneHeaderText!
-                                }
-                                configDefaultHeaderIcon={
-                                    val.pane === paneType.ONE
-                                        ? defaultConfig.onePane?.paneHeaderIcon!
-                                        : defaultConfig.twoPane?.paneHeaderIcon!
-                                }
-                            />
-                        </View>
-                        <View
-                            style={
-                                generalStyles(
-                                    paneType.ONE
-                                        ? defaultConfig.onePane?.paneHeader!
-                                        : defaultConfig.twoPane?.paneHeader!
-                                ).body
-                            }
-                        >
-                            {val.paneElement}
+                            >
+                                {val.paneElement}
+                            </View>
                         </View>
                     </View>
-                </View>
-            ))}
+                );
+            })}
         </Fragment>
     );
 };

--- a/twopane-navigation/src/onePane/onePaneStore/onePane.methods.ts
+++ b/twopane-navigation/src/onePane/onePaneStore/onePane.methods.ts
@@ -91,7 +91,7 @@ const GoBack = () => {
 
   store.dispatch(removeHeaderByKey(onePaneState.peek().key));
   store.dispatch(removePaneElementByKey(onePaneState.peek().key));
-  store.dispatch(popScreen(paneType.ONE));
+  store.dispatch(popScreen(onePaneState.peek().key));
 
 };
 

--- a/twopane-navigation/src/shared/screenStore/headerStore/header.interface.ts
+++ b/twopane-navigation/src/shared/screenStore/headerStore/header.interface.ts
@@ -6,6 +6,8 @@ export interface IHeader {
     IconPress?: () => void;
     style?: StyleProp<ViewStyle>; //expand this out
     leftIcon?: ReactElement;
+    canGoBack?: boolean;
+    buttonAccessibilityLabel?: string;
 }
 
 export interface IHeaderObject {

--- a/twopane-navigation/src/shared/screenStore/keyStore/key.actions.ts
+++ b/twopane-navigation/src/shared/screenStore/keyStore/key.actions.ts
@@ -1,3 +1,4 @@
+import { IKeyOnlyAction } from 'src';
 import { IExtensionOptions, paneType } from "../../../utilities/interfaces";
 import { IKeyAction, IScreenOnlyAction, IKeyScreenAction } from "./key.interface";
 import { PUSH_KEY, POP_KEY, MOVE_TO_FRONT_KEY, REMOVE_KEY, CHANGE_SCREEN_KEY, POP_TO_FRONT_KEY } from "./key.types";
@@ -31,10 +32,10 @@ export const popToFront = (screen: paneType): IScreenOnlyAction => ({
 /**
  * Go back one element in the stack
  */
-export const popScreen = (screen: paneType): IScreenOnlyAction => ({
+export const popScreen = (key: string): IKeyOnlyAction => ({
     type: POP_KEY,
     payload: {
-        screen: screen
+        key: key
     }
 });
 

--- a/twopane-navigation/src/shared/screenStore/keyStore/key.reducer.ts
+++ b/twopane-navigation/src/shared/screenStore/keyStore/key.reducer.ts
@@ -43,26 +43,13 @@ const keyReducers = (
             };
         }
         case POP_KEY: {
-            const onePaneState = state.keys.filter(x => x.screen === paneType.ONE);
-            const twoPaneState = state.keys.filter(x => x.screen === paneType.TWO);
-
-            if (action.payload.screen === paneType.ONE) {
-                //safety guard
-                if(onePaneState.length > 1)
-                {
-                    onePaneState.pop();
-                }
-            } else {
-                //safety guard
-                if(twoPaneState.length > 1)
-                {
-                    twoPaneState.pop();
-                }
-            }
+            const newKeys = state.keys;
+            const keyIndexToRemove = newKeys.findIndex(x => x.key === action.payload.key);
+            newKeys.splice(keyIndexToRemove, 1);
 
             return {
                 ...state,
-                keys: [...onePaneState, ...twoPaneState]
+                keys: newKeys
             };
         }
         case MOVE_TO_FRONT_KEY: {

--- a/twopane-navigation/src/twoPane/twoPaneStore/twoPane.methods.ts
+++ b/twopane-navigation/src/twoPane/twoPaneStore/twoPane.methods.ts
@@ -92,7 +92,7 @@ const GoBack = () => {
 
   store.dispatch(removeHeaderByKey(twoPaneState.peek().key));
   store.dispatch(removePaneElementByKey(twoPaneState.peek().key));
-  store.dispatch(popScreen(paneType.TWO));
+  store.dispatch(popScreen(twoPaneState.peek().key));
 
 };
 


### PR DESCRIPTION
This was a mistake on my part. If the importantForAccessibility prop is used on the top-most element in the pane render then nothing shows up for some reason. 