### PR TITLE
Use `getInsets` instead of `getInsetsIgnoringVisbility`.

### DIFF
--- a/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
+++ b/dualscreeninfo/android/src/main/kotlin/com/microsoft/reactnativedualscreen/dualscreen/DualScreenInfo.kt
@@ -38,21 +38,21 @@ class DualScreenInfo constructor(context: ReactApplicationContext) : ReactContex
 	private val mStatusBarHeight: Int
 		@RequiresApi(Build.VERSION_CODES.R)
 		get() {
-			val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())?.top
+			val stableInsetTop = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.getInsets(WindowInsets.Type.systemBars())?.top
 			return stableInsetTop ?: 0
 		}
 
 	private val mBottomNavBarHeight: Int
 		@RequiresApi(Build.VERSION_CODES.R)
 		get() {
-			val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())?.bottom
+			val stableInsetBottom = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.getInsets(WindowInsets.Type.systemBars())?.bottom
 			return stableInsetBottom ?: 0
 		}
 
 	private val mSideNavBarHeight: Int
 		@RequiresApi(Build.VERSION_CODES.R)
 		get() {
-			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())?.right
+			val stableInsetRight = currentActivity?.window?.decorView?.rootView?.rootWindowInsets?.getInsets(WindowInsets.Type.systemBars())?.right
 			return stableInsetRight ?: 0
 		}
 


### PR DESCRIPTION
Using `getInsetsIgnoringVisibility` as its name suggests ignores whether the specific inset under query is currently visible on screen or not.
As a result, this means the caller will always get windowRects as if the nav-bar/status-bar/etc. are visible on screen while in reality they could be in Immersive mode, at which point the windowRects would be incorrect.

Just a thought: also suggesting extending the API in the future to allow the caller to decide which of the two variants of values they seek. Someone might find it beneficial to always get the rects as if insets are present, to then treat it as a "safe area" to avoid putting UI elements such as swipeable elements in the (hidden) navbar area, as swiping on said elements would also trigger showing the navbar...