### PR TITLE
Remove JCenter

### DIFF
--- a/dualscreeninfo/android/build.gradle
+++ b/dualscreeninfo/android/build.gradle
@@ -37,7 +37,6 @@ android {
 
 rootProject.allprojects {
     repositories {
-        jcenter()
         google()
         maven {
             url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'


### PR DESCRIPTION
JCenter repo was deprecated late 2024, the install currently fails with this declaration.